### PR TITLE
chore: speed up version check via jsDelivr

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,6 @@
 app:
-  version_check_url: "https://raw.githubusercontent.com/sansan0/TrendRadar/refs/heads/master/version"
+  # 使用 jsDelivr CDN 以减少缓存延迟，及时获取 GitHub Pages 更新
+  version_check_url: "https://fastly.jsdelivr.net/gh/sansan0/TrendRadar@master/version"
   show_version_update: true # 控制显示版本更新提示，改成 false 将不接受新版本提示
 
 crawler:


### PR DESCRIPTION
## Summary
- use jsDelivr CDN for version file to reduce caching delays and see GitHub Pages updates faster

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b04a11d0048326b8f26aa0eae76b8c