### PR TITLE
fix: disable caching for instant GitHub Pages updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
     <title>热点新闻分析</title>
     <style>
       * {


### PR DESCRIPTION
## Summary
- add meta cache-control tags to page head to avoid browser caching

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b04a11d0048326b8f26aa0eae76b8c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled client-side caching to ensure users always receive the latest content.
  * Added cache-control directives in the page head (no-cache, no-store, must-revalidate; pragma no-cache; expires 0).
  * Reduces stale pages after deployments; updates appear without hard refresh.
  * No changes to UI or functionality; only affects how content is refreshed and loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->